### PR TITLE
add zlib work plan

### DIFF
--- a/content/en/initiative/zlib.html
+++ b/content/en/initiative/zlib.html
@@ -12,6 +12,14 @@ image: /images/zlib.png
   zlib is a data compression library that has been around since 1995. It's quite useful and as a result it's widely used. Unfortunately it has a history of memory safety vulnerabilities, a common phenomenon for compression libraries written in C/C++.
 </p>
 
+<p>
+We will implement a performant version of zlib in rust. This project has two goals:
+<ul>
+    <li>provide a pure rust implementation of zlib to rust users</li>
+    <li>provide a zlib-compatible dynamic library that has compiled rust code inside</li>
+</ul>
+</p>
+
 <h2>What We've Done</h2>
 
 <p>We contracted with <a href="https://tweedegolf.nl/">Tweede Golf</a> in December of 2023 for an <a href="https://github.com/memorysafety/zlib-rs/">initial implementation</a> based on <a href="https://github.com/zlib-ng/zlib-ng">zlib-ng</a>, with a focus on maintaining excellent performance while introducing memory safety.</p>
@@ -26,4 +34,5 @@ image: /images/zlib.png
 
 <ul>
   <li><a href="https://github.com/memorysafety/zlib-rs/">GitHub Repository</a></li>
+  <li><a href="/initiative/zlib/zlib-work-plan/">Work Plan</a></li>
 </ul>

--- a/content/en/initiative/zlib/zlib-work-plan.md
+++ b/content/en/initiative/zlib/zlib-work-plan.md
@@ -1,0 +1,29 @@
+---
+title: zlib
+slug: zlib-work-plan
+background: dce0e9
+image: /images/zlib.png
+---
+
+# Work Plan
+
+1. Pure Rust implementation
+  * Implement zlib compression and decompression in pure rust
+  * Fuzz output versus zlib-ng
+2. C API layer and security verification
+  * Complete the C interface to mirror (at the ABI level) the zlib api
+  * Fuzz the public interface
+3. Integrate with flate2
+  * Alternative zlib backend through C interface
+  * Ensure the implementation works on all platforms (Windows, Linux, Macos) 
+4. Benchmarking
+  * Benchmark on CI (similar to rustls)
+  * Benchmark for all supported architectures 
+    * aarch64 (NEON)
+    * x86_64 (SSE, AVX2, AVX512)
+5. x86_64 and ARM optimizations
+  * Add SIMD acceleration based on zlib-ng
+  * Incorporate optimizations from other implementations
+6. First stable release
+  * Provide downloads for the dynamic library for supported platforms (x86_64 & aarch64 for linux, macos and windows)
+  * Stabilize and publish the safe rust API


### PR DESCRIPTION
Adds the workplan for zlib. 

We could mention that the latest flate2 release supports zlib-rs now. Would that fit in the "what we've done" section?