### PR TITLE
Prevent nesting site in iFrame

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -27,6 +27,12 @@
   command = "hugo -b $DEPLOY_PRIME_URL --buildFuture"
 
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    Content-Security-Policy = "frame-ancestors 'none'"
+
 [[redirects]]
   from = "https://memorysafety.dev/*"
   to = "https://www.memorysafety.org/:splat"


### PR DESCRIPTION
Adds X-Frame-Options (legacy header) and CSP frame-ancestors (modern CSP equivalent) headers to prevent this site from being embedded in an iframe on other domains. See https://github.com/letsencrypt/website/pull/1080 and https://github.com/letsencrypt/website/pull/2148.